### PR TITLE
last days in enrollment_by_site_last_days_var_disc now as an argument

### DIFF
--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -2522,7 +2522,9 @@ expected_and_followup_visit_by_site <- function(analytic){
 #' \dontrun{
 #' enrollment_by_site_last_days_var_disc()
 #' }
-enrollment_by_site_last_days_var_disc <- function(analytic, days, discontinued="discontinued", discontinued_colname="Discontinued", include_safety_set=FALSE){
+enrollment_by_site_last_days_var_disc <- function(analytic, days = 0, discontinued="discontinued", discontinued_colname="Discontinued", include_safety_set=FALSE){
+  
+  if(days == 0){
   
   if(include_safety_set){
     df <- analytic %>% 
@@ -2535,8 +2537,6 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days, discontinued="
   }
   
   colnames(df)[10] <- "discontinued"
-  
-  last14 <- Sys.Date() - days
   
   df <- df %>% 
     mutate_if(is.logical, ~ifelse(is.na(.), FALSE, .)) %>% 
@@ -2574,19 +2574,6 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days, discontinued="
     select(Facility) %>% 
     unique()
   
-  last_fourteen <- df %>% 
-    mutate(screened_date = ymd(screened_date)) %>% 
-    mutate(screened_last_fourteen = ifelse(screened_date > last14, TRUE, FALSE)) %>% 
-    mutate(eligible_last_fourteen = ifelse(screened_last_fourteen, eligible, FALSE)) %>% 
-    mutate(enrolled_last_fourteen = ifelse(screened_last_fourteen, enrolled, FALSE)) %>% 
-    select(Facility, screened_last_fourteen, eligible_last_fourteen, enrolled_last_fourteen) %>% 
-    group_by(Facility) %>% 
-    summarize('Screened1' = sum(screened_last_fourteen, na.rm = T),
-              'Eligible1' = sum(eligible_last_fourteen, na.rm = T),
-              'Enrolled1' = sum(enrolled_last_fourteen, na.rm = T))
-  
-  l14 <- left_join(facilities, last_fourteen) 
-  
   by_week <- df %>%
     filter(!is.na(weeks_site_certified)) %>% 
     select(Facility, screened, enrolled, weeks_site_certified) %>% 
@@ -2597,11 +2584,9 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days, discontinued="
   
   weekly <- left_join(facilities, by_week, by = 'Facility')
   
-  almost <- left_join(l14, weekly, by = 'Facility')
-  
   sum_days_certified <- sum(table_raw$`Days Certified`, na.rm=T)
   
-  final <- left_join(almost, table_raw, by = 'Facility') %>% 
+  final <- left_join(weekly, table_raw, by = 'Facility') %>% 
     adorn_totals("row") %>% 
     mutate(is_total=Facility=="Total") %>% 
     mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
@@ -2621,31 +2606,27 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days, discontinued="
     last <- bind_rows(final, total_row) %>% 
       slice_tail(n=-1) %>% 
       select(-Eligible, -Enrolled, -Refused, -`Not Consented`, -cnr, -Discontinued) %>% 
-      select(Facility, Screened1, Eligible1, Enrolled1, Screened2, Enrolled2, Screened, `Eligible (% screened)`, `Refused (% eligible)`, `Not Enrolled for 'Other' Reasons (% eligible)`, 
-             `Consented & Randomized (% eligible)`, `Discontinued (% randomized)`, `Safety Set`, `Eligible & Enrolled (% randomized)`) %>% 
-      mutate(`Eligible1` = format_count_percent(`Eligible1`, `Screened1`),
-             `Enrolled1` = format_count_percent(`Enrolled1`, `Screened1`))
+      select(Facility, Screened2, Enrolled2, Screened, `Eligible (% screened)`, `Refused (% eligible)`, `Not Enrolled for 'Other' Reasons (% eligible)`, 
+             `Consented & Randomized (% eligible)`, `Discontinued (% randomized)`, `Safety Set`, `Eligible & Enrolled (% randomized)`)
     
-    colnames(last) <- c('Facility', 'Screened', 'Eligible (% screened)', 'Enrolled (% screened)', "Screened", 'Enrolled', 'Screened', 'Eligible (% screened)', 'Refused (% eligible)', 'Not Enrolled for `Other` Reasons (% eligible)', 
+    colnames(last) <- c('Facility', "Screened", 'Enrolled', 'Screened', 'Eligible (% screened)', 'Refused (% eligible)', 'Not Enrolled for `Other` Reasons (% eligible)', 
                         'Consented & Randomized (% eligible)', paste(discontinued_colname, '(% randomized)'), 'Safety Set', 'Eligible & Enrolled (% randomized)' )
     
-    header_num <- c(1,3,2,8)
-    header_names <- c(" ", paste("Last", days, " Days"), paste("Average per week"), paste("Cumulative", "to date"))
+    header_num <- c(1,2,8)
+    header_names <- c(" ", paste("Average per week"), paste("Cumulative", "to date"))
     names(header_num) <- header_names
   } else{
     last <- bind_rows(final, total_row) %>% 
       slice_tail(n=-1) %>% 
       select(-Eligible, -Enrolled, -Refused, -`Not Consented`, -cnr, -Discontinued) %>% 
-      select(Facility, Screened1, Eligible1, Enrolled1, Screened2, Enrolled2, Screened, `Eligible (% screened)`, `Refused (% eligible)`, `Not Enrolled for 'Other' Reasons (% eligible)`, 
-             `Consented & Randomized (% eligible)`, `Discontinued (% randomized)`, `Eligible & Enrolled (% randomized)`) %>% 
-      mutate(`Eligible1` = format_count_percent(`Eligible1`, `Screened1`),
-             `Enrolled1` = format_count_percent(`Enrolled1`, `Screened1`))
+      select(Facility, Screened2, Enrolled2, Screened, `Eligible (% screened)`, `Refused (% eligible)`, `Not Enrolled for 'Other' Reasons (% eligible)`, 
+             `Consented & Randomized (% eligible)`, `Discontinued (% randomized)`, `Eligible & Enrolled (% randomized)`)
     
-    colnames(last) <- c('Facility', 'Screened', 'Eligible (% screened)', 'Enrolled (% screened)', "Screened", 'Enrolled', 'Screened', 'Eligible (% screened)', 'Refused (% eligible)', 'Not Enrolled for `Other` Reasons (% eligible)', 
+    colnames(last) <- c('Facility', "Screened", 'Enrolled', 'Screened', 'Eligible (% screened)', 'Refused (% eligible)', 'Not Enrolled for `Other` Reasons (% eligible)', 
                         'Consented & Randomized (% eligible)', paste(discontinued_colname, '(% randomized)'), 'Eligible & Enrolled (% randomized)' )
     
-    header_num <- c(1,3,2,7)
-    header_names <- c(" ", paste("Last", days, " Days"), paste("Average per week"), paste("Cumulative", "to date"))
+    header_num <- c(1,2,7)
+    header_names <- c(" ", paste("Average per week"), paste("Cumulative", "to date"))
     names(header_num) <- header_names
   }
   
@@ -2655,6 +2636,139 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days, discontinued="
     row_spec(nrow(last), bold = TRUE)
   
   return(table)
+  }else{
+    if(include_safety_set){
+      df <- analytic %>% 
+        select(screened, eligible, refused, not_consented, not_randomized, consented_and_randomized, enrolled, site_certified_days, 
+               facilitycode, all_of(discontinued), screened_date, safety_set)
+    } else{
+      df <- analytic %>% 
+        select(screened, eligible, refused, not_consented, not_randomized, consented_and_randomized, enrolled, site_certified_days, 
+               facilitycode, all_of(discontinued), screened_date)
+    }
+    
+    colnames(df)[10] <- "discontinued"
+    
+    last14 <- Sys.Date() - days
+    
+    df <- df %>% 
+      mutate_if(is.logical, ~ifelse(is.na(.), FALSE, .)) %>% 
+      mutate(site_certified_days = as.numeric(Sys.Date() - as.Date(site_certified_days))) %>% 
+      rename(Facility = facilitycode) %>% 
+      filter(!is.na(Facility)) %>% 
+      mutate(weeks_site_certified = site_certified_days/7)
+    
+    if(include_safety_set){
+      df_1st <- df %>% 
+        group_by(Facility) %>% 
+        summarize('Days Certified' = site_certified_days[1], Screened = sum(screened), Eligible = sum(eligible), 
+                  Refused = sum(refused[eligible == TRUE]), 'Not Consented' = sum(not_consented[eligible == TRUE]), cnr = sum(consented_and_randomized[eligible == TRUE])) 
+      
+      df_2nd <- df %>% 
+        group_by(Facility) %>% 
+        summarize('Discontinued' = sum(discontinued[eligible == TRUE & consented_and_randomized == TRUE]), "Enrolled" = sum(enrolled[eligible == TRUE & consented_and_randomized == TRUE]), 'Safety Set' = sum(safety_set[eligible == TRUE & consented_and_randomized == TRUE])) %>% 
+        select(Facility, Discontinued, Enrolled, `Safety Set`)
+      
+    } else{
+      df_1st <- df %>% 
+        group_by(Facility) %>% 
+        summarize('Days Certified' = site_certified_days[1], Screened = sum(screened), Eligible = sum(eligible), 
+                  Refused = sum(refused[eligible == TRUE]), 'Not Consented' = sum(not_consented[eligible == TRUE]), cnr = sum(consented_and_randomized[eligible == TRUE])) 
+      
+      df_2nd <- df %>% 
+        group_by(Facility) %>% 
+        summarize('Discontinued' = sum(discontinued[eligible == TRUE & consented_and_randomized == TRUE]), "Enrolled" = sum(enrolled[eligible == TRUE & consented_and_randomized == TRUE])) %>% 
+        select(Facility, Discontinued, Enrolled)
+    }
+    
+    table_raw <- left_join(df_1st, df_2nd, by = 'Facility')
+    
+    facilities <- df %>% 
+      select(Facility) %>% 
+      unique()
+    
+    last_fourteen <- df %>% 
+      mutate(screened_date = ymd(screened_date)) %>% 
+      mutate(screened_last_fourteen = ifelse(screened_date > last14, TRUE, FALSE)) %>% 
+      mutate(eligible_last_fourteen = ifelse(screened_last_fourteen, eligible, FALSE)) %>% 
+      mutate(enrolled_last_fourteen = ifelse(screened_last_fourteen, enrolled, FALSE)) %>% 
+      select(Facility, screened_last_fourteen, eligible_last_fourteen, enrolled_last_fourteen) %>% 
+      group_by(Facility) %>% 
+      summarize('Screened1' = sum(screened_last_fourteen, na.rm = T),
+                'Eligible1' = sum(eligible_last_fourteen, na.rm = T),
+                'Enrolled1' = sum(enrolled_last_fourteen, na.rm = T))
+    
+    l14 <- left_join(facilities, last_fourteen) 
+    
+    by_week <- df %>%
+      filter(!is.na(weeks_site_certified)) %>% 
+      select(Facility, screened, enrolled, weeks_site_certified) %>% 
+      group_by(Facility) %>% 
+      summarize(
+        Screened2 = round(sum(screened, na.rm = TRUE) / first(weeks_site_certified), 2),
+        Enrolled2 = round(sum(enrolled, na.rm = TRUE) / first(weeks_site_certified), 2))
+    
+    weekly <- left_join(facilities, by_week, by = 'Facility')
+    
+    almost <- left_join(l14, weekly, by = 'Facility')
+    
+    sum_days_certified <- sum(table_raw$`Days Certified`, na.rm=T)
+    
+    final <- left_join(almost, table_raw, by = 'Facility') %>% 
+      adorn_totals("row") %>% 
+      mutate(is_total=Facility=="Total") %>% 
+      mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
+      arrange(desc(is_total), Facility) %>% 
+      select(-is_total) %>% 
+      mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
+      mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
+      mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
+      mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
+      mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
+      mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
+    
+    total_row <- final %>% 
+      slice_head(n=1)
+    
+    if(include_safety_set){
+      last <- bind_rows(final, total_row) %>% 
+        slice_tail(n=-1) %>% 
+        select(-Eligible, -Enrolled, -Refused, -`Not Consented`, -cnr, -Discontinued) %>% 
+        select(Facility, Screened1, Eligible1, Enrolled1, Screened2, Enrolled2, Screened, `Eligible (% screened)`, `Refused (% eligible)`, `Not Enrolled for 'Other' Reasons (% eligible)`, 
+               `Consented & Randomized (% eligible)`, `Discontinued (% randomized)`, `Safety Set`, `Eligible & Enrolled (% randomized)`) %>% 
+        mutate(`Eligible1` = format_count_percent(`Eligible1`, `Screened1`),
+               `Enrolled1` = format_count_percent(`Enrolled1`, `Screened1`))
+      
+      colnames(last) <- c('Facility', 'Screened', 'Eligible (% screened)', 'Enrolled (% screened)', "Screened", 'Enrolled', 'Screened', 'Eligible (% screened)', 'Refused (% eligible)', 'Not Enrolled for `Other` Reasons (% eligible)', 
+                          'Consented & Randomized (% eligible)', paste(discontinued_colname, '(% randomized)'), 'Safety Set', 'Eligible & Enrolled (% randomized)' )
+      
+      header_num <- c(1,3,2,8)
+      header_names <- c(" ", paste("Last", days, " Days"), paste("Average per week"), paste("Cumulative", "to date"))
+      names(header_num) <- header_names
+    } else{
+      last <- bind_rows(final, total_row) %>% 
+        slice_tail(n=-1) %>% 
+        select(-Eligible, -Enrolled, -Refused, -`Not Consented`, -cnr, -Discontinued) %>% 
+        select(Facility, Screened1, Eligible1, Enrolled1, Screened2, Enrolled2, Screened, `Eligible (% screened)`, `Refused (% eligible)`, `Not Enrolled for 'Other' Reasons (% eligible)`, 
+               `Consented & Randomized (% eligible)`, `Discontinued (% randomized)`, `Eligible & Enrolled (% randomized)`) %>% 
+        mutate(`Eligible1` = format_count_percent(`Eligible1`, `Screened1`),
+               `Enrolled1` = format_count_percent(`Enrolled1`, `Screened1`))
+      
+      colnames(last) <- c('Facility', 'Screened', 'Eligible (% screened)', 'Enrolled (% screened)', "Screened", 'Enrolled', 'Screened', 'Eligible (% screened)', 'Refused (% eligible)', 'Not Enrolled for `Other` Reasons (% eligible)', 
+                          'Consented & Randomized (% eligible)', paste(discontinued_colname, '(% randomized)'), 'Eligible & Enrolled (% randomized)' )
+      
+      header_num <- c(1,3,2,7)
+      header_names <- c(" ", paste("Last", days, " Days"), paste("Average per week"), paste("Cumulative", "to date"))
+      names(header_num) <- header_names
+    }
+    
+    table <- kable(last, format="html",, align='l') %>%
+      add_header_above(header_num) %>%
+      kable_styling("striped", full_width = F, position="left") %>% 
+      row_spec(nrow(last), bold = TRUE)
+    
+    return(table)
+  }
 }
 
 

--- a/man/.gitignore
+++ b/man/.gitignore
@@ -1,0 +1,1 @@
+primary_outcomes.Rd

--- a/man/enrollment_by_site_last_days_var_disc.Rd
+++ b/man/enrollment_by_site_last_days_var_disc.Rd
@@ -6,7 +6,7 @@
 \usage{
 enrollment_by_site_last_days_var_disc(
   analytic,
-  days,
+  days = 0,
   discontinued = "discontinued",
   discontinued_colname = "Discontinued",
   include_safety_set = FALSE


### PR DESCRIPTION
## Description of Changes
made the changes for the last days part of the enrollment function for tobra and sextant, now as an argument if set to zero wont return any of the last days columns

## References
<!-- Link any GitHub issues, Basecamp discussions, and sources, if needed. Otherwise delete this section -->

## Checklist Before Merge
- [ ] This pull request successfully passes the Github Action build.
- [ ] This pull request has been reviewed by one other contributor.
- [ ] There are no merge conflicts.
