### PR TITLE
added when() statement to enrollment_by_site_last_days_var_disc

### DIFF
--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -1852,43 +1852,27 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days = 0,
   
   sum_days_certified <- sum(table_raw$`Days Certified`, na.rm=T)
   
-  if(include_exclusive_safety_set){
-    final <- left_join(almost, table_raw, by = 'Facility') %>% 
-      adorn_totals("row") %>% 
-      mutate(is_total=Facility=="Total") %>% 
-      mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
-      arrange(desc(is_total), Facility) %>% 
-      select(-is_total) %>% 
-      mutate(across(starts_with(c("last_days_Eligible", "last_days_Enrolled")), 
-        ~ format_count_percent(.x, 
-                               get(str_replace(cur_column(), 
-                                               "^(last_days_Eligible|last_days_Enrolled)(.*)$", 
-                                               "last_days_Screened\\2"))))) %>% 
-      mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
-      mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
+  final <- left_join(almost, table_raw, by = 'Facility') %>% 
+    adorn_totals("row") %>% 
+    mutate(is_total=Facility=="Total") %>% 
+    mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
+    arrange(desc(is_total), Facility) %>% 
+    select(-is_total) %>% 
+    mutate(across(starts_with(c("last_days_Eligible", "last_days_Enrolled")), 
+      ~ format_count_percent(.x, 
+                             get(str_replace(cur_column(), 
+                                             "^(last_days_Eligible|last_days_Enrolled)(.*)$", 
+                                             "last_days_Screened\\2"))))) %>% 
+    mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
+    mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
+    mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
+    mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
+    mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
+    mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
+  
+  if (include_exclusive_safety_set) {
+    final <- final %>%
       mutate(`Safety Set` = format_count_percent(`Safety Set`, cnr)) %>% 
-      mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
-      mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
-      mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
-      mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
-  } else {
-    final <- left_join(almost, table_raw, by = 'Facility') %>% 
-      adorn_totals("row") %>% 
-      mutate(is_total=Facility=="Total") %>% 
-      mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
-      arrange(desc(is_total), Facility) %>% 
-      select(-is_total) %>% 
-      mutate(across(starts_with(c("last_days_Eligible", "last_days_Enrolled")), 
-                    ~ format_count_percent(.x, 
-                                           get(str_replace(cur_column(), 
-                                                           "^(last_days_Eligible|last_days_Enrolled)(.*)$", 
-                                                           "last_days_Screened\\2"))))) %>% 
-      mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
-      mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
-      mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
-      mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
-      mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
-      mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
   }
   
   total_row <- final %>% 

--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -1852,24 +1852,44 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days = 0,
   
   sum_days_certified <- sum(table_raw$`Days Certified`, na.rm=T)
   
-  final <- left_join(almost, table_raw, by = 'Facility') %>% 
-    adorn_totals("row") %>% 
-    mutate(is_total=Facility=="Total") %>% 
-    mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
-    arrange(desc(is_total), Facility) %>% 
-    select(-is_total) %>% 
-    mutate(across(starts_with(c("last_days_Eligible", "last_days_Enrolled")), 
-      ~ format_count_percent(.x, 
-                             get(str_replace(cur_column(), 
-                                             "^(last_days_Eligible|last_days_Enrolled)(.*)$", 
-                                             "last_days_Screened\\2"))))) %>% 
-    mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
-    mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
-    when(include_exclusive_safety_set ~ mutate(., `Safety Set` = format_count_percent(`Safety Set`, cnr)), ~ .) %>% 
-    mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
-    mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
-    mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
-    mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
+  if(include_exclusive_safety_set){
+    final <- left_join(almost, table_raw, by = 'Facility') %>% 
+      adorn_totals("row") %>% 
+      mutate(is_total=Facility=="Total") %>% 
+      mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
+      arrange(desc(is_total), Facility) %>% 
+      select(-is_total) %>% 
+      mutate(across(starts_with(c("last_days_Eligible", "last_days_Enrolled")), 
+        ~ format_count_percent(.x, 
+                               get(str_replace(cur_column(), 
+                                               "^(last_days_Eligible|last_days_Enrolled)(.*)$", 
+                                               "last_days_Screened\\2"))))) %>% 
+      mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
+      mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
+      mutate(`Safety Set` = format_count_percent(`Safety Set`, cnr)) %>% 
+      mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
+      mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
+      mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
+      mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
+  } else {
+    final <- left_join(almost, table_raw, by = 'Facility') %>% 
+      adorn_totals("row") %>% 
+      mutate(is_total=Facility=="Total") %>% 
+      mutate(`Days Certified`=ifelse(is_total,sum_days_certified,`Days Certified`)) %>% 
+      arrange(desc(is_total), Facility) %>% 
+      select(-is_total) %>% 
+      mutate(across(starts_with(c("last_days_Eligible", "last_days_Enrolled")), 
+                    ~ format_count_percent(.x, 
+                                           get(str_replace(cur_column(), 
+                                                           "^(last_days_Eligible|last_days_Enrolled)(.*)$", 
+                                                           "last_days_Screened\\2"))))) %>% 
+      mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
+      mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
+      mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
+      mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
+      mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
+      mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
+  }
   
   total_row <- final %>% 
     slice_head(n=1)

--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -1755,7 +1755,12 @@ fracture_characteristics <- function(analytic){
 #' \dontrun{
 #' enrollment_by_site_last_days_var_disc()
 #' }
-enrollment_by_site_last_days_var_disc <- function(analytic, days = 0, discontinued="discontinued", discontinued_colname="Discontinued", include_exclusive_safety_set=FALSE, average = FALSE, cumulative_data = TRUE){
+enrollment_by_site_last_days_var_disc <- function(analytic, days = 0, 
+                                                  discontinued="discontinued", 
+                                                  discontinued_colname="Discontinued", 
+                                                  include_exclusive_safety_set=FALSE, 
+                                                  average = FALSE, 
+                                                  cumulative_data = TRUE){
   
   if(include_exclusive_safety_set){
     df <- analytic %>% 
@@ -1781,23 +1786,32 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days = 0, discontinu
   if(include_exclusive_safety_set){
     df_1st <- df %>% 
       group_by(Facility) %>% 
-      summarize('Days Certified' = site_certified_days[1], Screened = sum(screened), Eligible = sum(eligible), 
-                Refused = sum(refused[eligible == TRUE]), 'Not Consented' = sum(not_consented[eligible == TRUE]), cnr = sum(consented_and_randomized[eligible == TRUE])) 
+      summarize('Days Certified' = site_certified_days[1], 
+                Screened = sum(screened), Eligible = sum(eligible), 
+                Refused = sum(refused[eligible == TRUE]), 
+                'Not Consented' = sum(not_consented[eligible == TRUE]), 
+                cnr = sum(consented_and_randomized[eligible == TRUE])) 
     
     df_2nd <- df %>% 
       group_by(Facility) %>% 
-      summarize('Discontinued' = sum(discontinued[eligible == TRUE & consented_and_randomized == TRUE]), "Enrolled" = sum(enrolled[eligible == TRUE & consented_and_randomized == TRUE]), 'Safety Set' = sum(exclusive_safety_set[eligible == TRUE & consented_and_randomized == TRUE])) %>% 
+      summarize('Discontinued' = sum(discontinued[eligible == TRUE & consented_and_randomized == TRUE]), 
+                "Enrolled" = sum(enrolled[eligible == TRUE & consented_and_randomized == TRUE]), 
+                'Safety Set' = sum(exclusive_safety_set[eligible == TRUE & consented_and_randomized == TRUE])) %>% 
       select(Facility, Discontinued, Enrolled, `Safety Set`)
     
   } else{
     df_1st <- df %>% 
       group_by(Facility) %>% 
-      summarize('Days Certified' = site_certified_days[1], Screened = sum(screened), Eligible = sum(eligible), 
-                Refused = sum(refused[eligible == TRUE]), 'Not Consented' = sum(not_consented[eligible == TRUE]), cnr = sum(consented_and_randomized[eligible == TRUE])) 
+      summarize('Days Certified' = site_certified_days[1], 
+                Screened = sum(screened), Eligible = sum(eligible), 
+                Refused = sum(refused[eligible == TRUE]), 
+                'Not Consented' = sum(not_consented[eligible == TRUE]), 
+                cnr = sum(consented_and_randomized[eligible == TRUE])) 
     
     df_2nd <- df %>% 
       group_by(Facility) %>% 
-      summarize('Discontinued' = sum(discontinued[eligible == TRUE & consented_and_randomized == TRUE]), "Enrolled" = sum(enrolled[eligible == TRUE & consented_and_randomized == TRUE])) %>% 
+      summarize('Discontinued' = sum(discontinued[eligible == TRUE & consented_and_randomized == TRUE]), 
+                "Enrolled" = sum(enrolled[eligible == TRUE & consented_and_randomized == TRUE])) %>% 
       select(Facility, Discontinued, Enrolled)
   }
   
@@ -1851,7 +1865,7 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days = 0, discontinu
                                              "last_days_Screened\\2"))))) %>% 
     mutate(`Discontinued (% randomized)` = format_count_percent(Discontinued, cnr)) %>% 
     mutate(`Eligible & Enrolled (% randomized)` = format_count_percent(Enrolled, cnr)) %>% 
-    mutate(`Safety Set` = format_count_percent(`Safety Set`, cnr)) %>% 
+    when(include_exclusive_safety_set ~ mutate(., `Safety Set` = format_count_percent(`Safety Set`, cnr)), ~ .) %>% 
     mutate(`Consented & Randomized (% eligible)` = format_count_percent(cnr, Eligible)) %>% 
     mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
     mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 

--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -1872,7 +1872,7 @@ enrollment_by_site_last_days_var_disc <- function(analytic, days = 0,
   
   if (include_exclusive_safety_set) {
     final <- final %>%
-      mutate(`Safety Set` = format_count_percent(`Safety Set`, cnr)) %>% 
+      mutate(`Safety Set` = format_count_percent(`Safety Set`, cnr))
   }
   
   total_row <- final %>% 


### PR DESCRIPTION
## Description of Changes
enrollment_by_site_last_days_var_disc was broken when not handling the safety set because of a forced mutate. I wrapped the mutate statement in a when call to fix it. when() seems like an interesting function

## Checklist Before Merge
- [ ] This pull request successfully passes the Github Action build.
- [ ] This pull request has been reviewed by one other contributor.
- [ ] There are no merge conflicts.
