### PR TITLE
deviation data visualizations now correct

### DIFF
--- a/R/closed_tables.R
+++ b/R/closed_tables.R
@@ -533,7 +533,7 @@ closed_not_complete_sae_deviation_by_type <- function(analytic){
     deviation_df_tot <- tibble(type="Protocol Deviations",n=sum(deviation_sc_df$n)+sum(deviation_p_df$n)+sum(deviation_a_df$n))
     
     consented <- sum(analytic$consented, na.rm = TRUE)
-    consented_df <- tibble(type = " ", n = paste0("n=", consented, ' ', group, ' <sub>(Consented)</sub>'))
+    consented_df <- tibble(type = " ", n = paste0(group, " n=", consented, ' <sub>(Consented)</sub>'))
     
     df_final_top <- rbind(not_completed_df_tot, not_completed_df, not_expected_df_tot, not_expected_df, sae_df, consented_df) %>% 
       mutate(n = ifelse(type == " ", n,
@@ -699,7 +699,7 @@ closed_not_complete_sae_deviation_by_type_auto_categories <- function(analytic, 
     deviation_df_tot <- tibble(type="Protocol Deviations",n=sum(deviations_df$n))
     
     consented <- sum(analytic$consented, na.rm = TRUE)
-    consented_df <- tibble(type = " ", n = paste0("n=", consented, ' ', group, ' <sub>(Consented)</sub>'))
+    consented_df <- tibble(type = " ", n = paste0(group, " n=", consented, ' <sub>(Consented)</sub>'))
     
     df_final_top <- rbind(not_completed_df_tot, not_completed_df, not_expected_df_tot, not_expected_df, sae_df, consented_df) 
     df_final_bottom <- rbind(deviation_df_tot) 

--- a/R/closed_tables.R
+++ b/R/closed_tables.R
@@ -621,7 +621,7 @@ closed_not_complete_sae_deviation_by_type <- function(analytic){
 #' }
 closed_not_complete_sae_deviation_by_type_auto_categories <- function(analytic, category_defaults=c("Safety","Informed Consent","Eligibility","Protocol Implementation","Other")){
   
-  confirm_stability_of_related_visual('not_complete_sae_deviation_by_type_auto_categories', '784a7f67645a70a8e689c4db041561ea')
+  confirm_stability_of_related_visual('not_complete_sae_deviation_by_type_auto_categories', 'a23028eb9fd76744bbefab342f6dd6cd')
   
   n_act <- NA
   n_disc <- NA

--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -824,6 +824,8 @@ not_complete_sae_deviation_by_type <- function(analytic){
     sae_df <- tibble(type = "SAE", n = 0)
   }
   
+  consented <- sum(analytic$consented, na.rm = TRUE)
+  consented_df <- tibble(type = " ", n = paste0("n=", consented, ' <sub>(Consented)</sub>'))
   
   deviation_sc_df <- analytic %>% 
     select(study_id, consented, protocol_deviation_screen_consent) %>% 
@@ -862,10 +864,15 @@ not_complete_sae_deviation_by_type <- function(analytic){
   deviation_df_tot <- tibble(type="Protocol Deviations",n=sum(deviation_sc_df$n)+sum(deviation_p_df$n)+sum(deviation_a_df$n))
   
   
-  df_final <- bind_rows(not_completed_df_tot, not_completed_df, not_expected_df_tot, not_expected_df, sae_df, deviation_df_tot, 
-                        deviation_sc_tot, deviation_sc_df, deviation_p_tot, deviation_p_df, deviation_a_tot, deviation_a_df) %>% 
-    mutate(n = format_count_percent(n, total, decimals=2))
+  df_final_top <- rbind(not_completed_df_tot, not_completed_df, not_expected_df_tot, not_expected_df, sae_df, consented_df) %>% 
+    mutate(n = ifelse(type == " ", n,
+                      format_count_percent(n, total, decimals=2)))
   
+  df_final_bottom <- rbind(deviation_df_tot, deviation_sc_tot, deviation_sc_df, deviation_p_tot, deviation_p_df, deviation_a_tot, deviation_a_df) %>% 
+    mutate(n = ifelse(type == " ", n,
+                      format_count_percent(n, consented, decimals=2)))
+  
+  df_final <- rbind(df_final_top, df_final_bottom)
   
   n_act <- if (exists("not_completed_df")) nrow(not_completed_df) else 0
   n_disc <- if (exists("not_expected_df")) nrow(not_expected_df) else 0
@@ -876,34 +883,34 @@ not_complete_sae_deviation_by_type <- function(analytic){
   
   indents_vec <- vector()
   
-  
   if (n_dsc > 0) {
-    indents_vec <- c(indents_vec, 1 + n_act + 1 + n_disc + 1 + 1 + 1 + seq(n_dsc))
+    indents_vec <- c(indents_vec, 1 + n_act + 1 + n_disc + 1 + 1 + 1 + seq(n_dsc) + 1)
   }
   if (n_dp > 0) {
-    indents_vec <- c(indents_vec, 1 + n_act + 1 + n_disc + 1 + 1 + 1 + n_dsc + 1 + seq(n_dp))
+    indents_vec <- c(indents_vec, 1 + n_act + 1 + n_disc + 1 + 1 + 1 + n_dsc + 1 + seq(n_dp) + 1)
   }
   if (n_da > 0) {
-    indents_vec <- c(indents_vec, 1 + n_act + 1 + n_disc + 1 + 1 + 1 + n_dsc + 1 + n_dp + 1 + seq(n_da))
+    indents_vec <- c(indents_vec, 1 + n_act + 1 + n_disc + 1 + 1 + 1 + n_dsc + 1 + n_dp + 1 + seq(n_da) + 1)
   }
   
   
   indents_vec <- indents_vec[indents_vec <= nrow(df_final)]
   
   first_indents_vec <- c(ifelse(n_act==0, vector(mode="integer"), seq(n_act) + 1),
-                         ifelse(n_disc==0, vector(mode="integer"),seq(n_disc) + 1 + n_act + 1), seq(1+n_dsc+1+n_dp+1+n_da) + 1 + n_act + 1 + n_disc + 1 + 1)
+                         ifelse(n_disc==0, vector(mode="integer"),seq(n_disc) + 1 + n_act + 1), seq(1+n_dsc+1+n_dp+1+n_da) + 1 + n_act + 1 + n_disc + 1 + 1 + 1)
   
   first_indents_vec <- first_indents_vec[!is.na(first_indents_vec)]
   
   
-  vis <- kable(df_final, format = "html", align = 'l', col.names = c(" ", paste0("n=", total))) %>%
+  vis <- kable(df_final, format = "html", align = 'l', col.names = c(" ", paste0("n=", total, ' <sub>(Enrolled)</sub>')), escape = FALSE) %>%
     add_indent(first_indents_vec) %>% 
     add_indent(indents_vec) %>%
     row_spec(0, extra_css = "border-bottom: 1px solid") %>%
     row_spec(1 + n_act, extra_css = "border-bottom: 1px solid") %>%
     row_spec(1 + n_act + 1 + n_disc, extra_css = "border-bottom: 1px solid") %>%
     row_spec(1 + n_act + 1 + n_disc + 1, extra_css = "border-bottom: 1px solid") %>%
-    row_spec(1 + n_act + 1 + n_disc + 1 + 1 + 1 + n_dsc + 1 + n_dp + 1 + n_da, extra_css = "border-bottom: 1px solid") %>%
+    row_spec(1 + n_act + 1 + n_disc + 1 + 1, extra_css = "border-bottom: 1px solid; font-weight: bold") %>% 
+    row_spec(1 + n_act + 1 + n_disc + 1 + 1 + 1 + 1 + n_dsc + 1 + n_dp + 1 + n_da, extra_css = "border-bottom: 1px solid") %>%
     kable_styling("striped", full_width = F, position = "left")
   
   return(vis)
@@ -989,14 +996,18 @@ not_complete_sae_deviation_by_type_auto_categories <- function(analytic, categor
   
   deviation_df_tot <- tibble(type="Protocol Deviations",n=sum(deviations_df$n))
   
-  df_final <- bind_rows(not_completed_df_tot, not_completed_df, not_expected_df_tot, not_expected_df, sae_df, deviation_df_tot) 
+  consented <- sum(analytic$consented, na.rm = TRUE)
+  consented_df <- tibble(type = " ", n = paste0("n=", consented, ' <sub>(Consented)</sub>'))
+  
+  df_final_top <- rbind(not_completed_df_tot, not_completed_df, not_expected_df_tot, not_expected_df, sae_df, consented_df) 
+  df_final_bottom <- rbind(deviation_df_tot) 
   
   n_act <- if (exists("not_completed_df")) nrow(not_completed_df) else 0
   n_disc <- if (exists("not_expected_df")) nrow(not_expected_df) else 0
   
   indents_vec <- vector(mode="integer")
   
-  indents_offset <- 1
+  indents_offset <- 2
   
   if(n_act>0){
     indents_vec <- c(indents_offset+seq(n_act))
@@ -1021,7 +1032,7 @@ not_complete_sae_deviation_by_type_auto_categories <- function(analytic, categor
     
     tot_df <- tibble(type=category_i,n=sum(category_df$n))
     
-    df_final <- bind_rows(df_final, tot_df, category_df)
+    df_final_bottom <- rbind(df_final_bottom, tot_df, category_df)
     indents_vec <- c(indents_vec,indents_offset+1)
     indents_offset <-indents_offset+1
     second_offset <-second_offset+1
@@ -1034,26 +1045,35 @@ not_complete_sae_deviation_by_type_auto_categories <- function(analytic, categor
     }
   }
   
-  df_final <- df_final %>% 
-    mutate(n = format_count_percent(n, total, decimals=2))
+  df_final_top <- df_final_top %>% 
+    mutate(n = ifelse(type == " ", n,
+                      format_count_percent(n, total, decimals=2)))
+  
+  df_final_bottom <- df_final_bottom %>% 
+    mutate(n = ifelse(type == " ", n,
+                      format_count_percent(n, consented, decimals=2)))
+  
+  df_final <- rbind(df_final_top, df_final_bottom)
   
   if(is_empty(second_vec)){
-    vis <- kable(df_final, format = "html", align = 'l', col.names = c(" ", paste0("n=", total))) %>%
+    vis <- kable(df_final, format = "html", align = 'l', col.names = c(" ", paste0("n=", total, ' <sub>(Enrolled)</sub>')), escape = FALSE) %>%
       add_indent(indents_vec) %>% 
       row_spec(0, extra_css = "border-bottom: 1px solid") %>%
       row_spec(1 + n_act, extra_css = "border-bottom: 1px solid") %>%
       row_spec(1 + n_act + 1 + n_disc, extra_css = "border-bottom: 1px solid") %>%
       row_spec(1 + n_act + 1 + n_disc + 1, extra_css = "border-bottom: 1px solid") %>%
+      row_spec(1 + n_act + 1 + n_disc + 1 + 1, extra_css = "border-bottom: 1px solid; font-weight: bold") %>% 
       row_spec(nrow(df_final), extra_css = "border-bottom: 1px solid") %>% 
       kable_styling("striped", full_width = F, position = "left")
   } else{
-    vis <- kable(df_final, format = "html", align = 'l', col.names = c(" ", paste0("n=", total))) %>%
+    vis <- kable(df_final, format = "html", align = 'l', col.names = c(" ", paste0("n=", total, ' <sub>(Enrolled)</sub>')), escape = FALSE) %>%
       add_indent(indents_vec) %>% 
       add_indent(second_vec) %>%
       row_spec(0, extra_css = "border-bottom: 1px solid") %>%
       row_spec(1 + n_act, extra_css = "border-bottom: 1px solid") %>%
       row_spec(1 + n_act + 1 + n_disc, extra_css = "border-bottom: 1px solid") %>%
       row_spec(1 + n_act + 1 + n_disc + 1, extra_css = "border-bottom: 1px solid") %>%
+      row_spec(1 + n_act + 1 + n_disc + 1 + 1, extra_css = "border-bottom: 1px solid; font-weight: bold") %>% 
       row_spec(nrow(df_final), extra_css = "border-bottom: 1px solid") %>% 
       kable_styling("striped", full_width = F, position = "left")
   }

--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -975,11 +975,11 @@ not_complete_sae_deviation_by_type_auto_categories <- function(analytic, categor
   
   
   deviations_df <- analytic %>% 
-    select(study_id, enrolled, protocol_deviation_data) %>% 
+    select(study_id, consented, protocol_deviation_data) %>% 
     separate_rows(protocol_deviation_data, sep = ";new_row: ") %>% 
     separate(protocol_deviation_data, into = c("facilitycode", "consent_date", "category", "deviation_date", "protocol_deviation", 
                                                "deviation_description"), sep='\\|') %>% 
-    filter(enrolled == TRUE & !is.na(protocol_deviation)) %>% 
+    filter(consented & !is.na(protocol_deviation)) %>% 
     mutate(protocol_deviation = ifelse(str_detect(protocol_deviation,"^Other:"), "Other", protocol_deviation)) %>% 
     count(category, protocol_deviation) %>%
     rename(type=protocol_deviation) %>% 


### PR DESCRIPTION
## Description of Changes
both the closed and open versions of not_complete sae and deviation data now: 
contain n=consented above deviation data
deviation data is divided by the number consented
both n=enrolled and n=consented have "Enrolled" and "Consented" in subscript adjacent
for closed: displays groups next to consented n= (in accordance with header)
## References
<!-- Link any GitHub issues, Basecamp discussions, and sources, if needed. Otherwise delete this section -->

## Checklist Before Merge
- [ ] This pull request successfully passes the Github Action build.
- [ ] This pull request has been reviewed by one other contributor.
- [ ] There are no merge conflicts.
