### PR TITLE
Fixed issue that turns Other to a code block

### DIFF
--- a/R/standard_tables.R
+++ b/R/standard_tables.R
@@ -2999,7 +2999,7 @@ enrollment_by_site_last_days_var_disc_i <- function(analytic, days = 0,
                                                          "^last_days_Eligible(.*)$", 
                                                          "last_days_Screened\\1"))))) %>% 
     mutate(`Refused (% eligible)` = format_count_percent(Refused, Eligible)) %>% 
-    mutate(`Not Enrolled for 'Other' Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
+    mutate(`Not Enrolled for Other Reasons (% eligible)` = format_count_percent(`Not Consented`, Eligible)) %>% 
     mutate(`Eligible (% screened)` = format_count_percent(Eligible, Screened)) 
   
   total_row <- final %>% 


### PR DESCRIPTION
## Description of Changes
Heres a snippit of how the html is coded. The single quotes get turned to backticks, and I don't think they're necessary as the haven't been visible anyways.

 <thead>
<tr>
<th style="empty-cells: hide;border-bottom:hidden;" colspan="1"></th>
<th style="border-bottom:hidden;padding-bottom:0; padding-left:3px;padding-right:3px;text-align: center; " colspan="4"><div style="border-bottom: 1px solid #ddd; padding-bottom: 5px; ">Cumulative to date</div></th>
</tr>
  <tr>
   <th style="text-align:left;"> Facility </th>
   <th style="text-align:left;"> Screened </th>
   <th style="text-align:left;"> Eligible (% screened) </th>
   <th style="text-align:left;"> Refused (% eligible) </th>
   <th style="text-align:left;"> Not Enrolled for `Other` Reasons (% eligible) </th>
  </tr>
 </thead>

## Checklist Before Merge
- [ ] This pull request successfully passes the Github Action build.
- [ ] This pull request has been reviewed by one other contributor.
- [ ] There are no merge conflicts.
