### PR TITLE
Include R version in CI cache key to fix stale-ABI builds

### DIFF
--- a/.github/workflows/build-dev-releases.yml
+++ b/.github/workflows/build-dev-releases.yml
@@ -35,17 +35,20 @@ jobs:
         ref: main
         path: 'VisualizationTools'
         
-    - name: Generate cache key using the number of the month (01 to 12)
+    - name: Generate cache key using the number of the month (01 to 12) and the R version
       run: |
         date +%m
         echo "month_number=$(date +%m)" >> $GITHUB_ENV
+        r_version=$(R --version | head -n 1 | grep -oP '\d+\.\d+\.\d+')
+        echo "r_version=${r_version}" >> $GITHUB_ENV
+        echo "R version: ${r_version}"
 
     - name: check runner temp
-      run: | 
+      run: |
         echo $RUNNER_TEMP
 
     - name: Temporarily change ownership for R site library path, so our cache can write to it during a restore
-      run: | 
+      run: |
         chown -R $(whoami) /usr/local/lib/R/
         chown -R $(whoami) /usr/lib/R/
 
@@ -53,7 +56,7 @@ jobs:
       uses: actions/cache@v3
       id: cache-R-site-lib
       with:
-        key: ${{ env.month_number }}
+        key: ${{ env.month_number }}-R${{ env.r_version }}
         path: |
           /usr/local/lib/R/site-library
           /usr/lib/R/site-library

--- a/.github/workflows/build-main-releases.yml
+++ b/.github/workflows/build-main-releases.yml
@@ -35,17 +35,20 @@ jobs:
         ref: main
         path: 'VisualizationTools'
         
-    - name: Generate cache key using the number of the month (01 to 12)
+    - name: Generate cache key using the number of the month (01 to 12) and the R version
       run: |
         date +%m
         echo "month_number=$(date +%m)" >> $GITHUB_ENV
+        r_version=$(R --version | head -n 1 | grep -oP '\d+\.\d+\.\d+')
+        echo "r_version=${r_version}" >> $GITHUB_ENV
+        echo "R version: ${r_version}"
 
     - name: check runner temp
-      run: | 
+      run: |
         echo $RUNNER_TEMP
 
     - name: Temporarily change ownership for R site library path, so our cache can write to it during a restore
-      run: | 
+      run: |
         chown -R $(whoami) /usr/local/lib/R/
         chown -R $(whoami) /usr/lib/R/
 
@@ -53,7 +56,7 @@ jobs:
       uses: actions/cache@v3
       id: cache-R-site-lib
       with:
-        key: ${{ env.month_number }}
+        key: ${{ env.month_number }}-R${{ env.r_version }}
         path: |
           /usr/local/lib/R/site-library
           /usr/lib/R/site-library

--- a/.github/workflows/check-r-package.yml
+++ b/.github/workflows/check-r-package.yml
@@ -35,17 +35,20 @@ jobs:
         ref: main
         path: 'VisualizationTools'
         
-    - name: Generate cache key using the number of the month (01 to 12)
+    - name: Generate cache key using the number of the month (01 to 12) and the R version
       run: |
         date +%m
         echo "month_number=$(date +%m)" >> $GITHUB_ENV
+        r_version=$(R --version | head -n 1 | grep -oP '\d+\.\d+\.\d+')
+        echo "r_version=${r_version}" >> $GITHUB_ENV
+        echo "R version: ${r_version}"
 
     - name: check runner temp
-      run: | 
+      run: |
         echo $RUNNER_TEMP
 
     - name: Temporarily change ownership for R site library path, so our cache can write to it during a restore
-      run: | 
+      run: |
         chown -R $(whoami) /usr/local/lib/R/
         chown -R $(whoami) /usr/lib/R/
 
@@ -53,7 +56,7 @@ jobs:
       uses: actions/cache@v3
       id: cache-R-site-lib
       with:
-        key: ${{ env.month_number }}
+        key: ${{ env.month_number }}-R${{ env.r_version }}
         path: |
           /usr/local/lib/R/site-library
           /usr/lib/R/site-library


### PR DESCRIPTION
## Summary
- The container image \`eliaswf/jammy-chromedriver-python-r:latest\` rolled forward to **R 4.6.0** (released 2026-04-24) between the last green build (2026-05-04) and the recent failure (2026-05-12).
- The Actions cache was keyed only on the month number, so the new R restored \`.so\` files compiled against the previous R. Loading \`rlang\` then failed with \`undefined symbol: SETLENGTH\`, cascading through ggplot2/tidyverse and breaking \`R CMD INSTALL\`.
- Cache key now includes the running R version (\`<month>-R<R version>\`), so any future R bump in the container auto-invalidates the cache instead of restoring binaries with a mismatched ABI.

Applied to all three workflows: \`build-dev-releases.yml\`, \`build-main-releases.yml\`, \`check-r-package.yml\`.

## Test plan
- [ ] Merge and observe that the next run records a cache miss, reinstalls dependencies from source, and produces a green build.
- [ ] Optionally delete the stale cache (id \`4131265249\`, key \`05\`, ~346 MiB) — not required, since the new key won't match it anyway.
- [ ] Consider pinning the container to a digest in a follow-up so \`:latest\` rollovers can't surprise CI again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)