### PR TITLE
Trust the Docker image: drop redundant install.packages step

### DIFF
--- a/.github/workflows/build-main-releases.yml
+++ b/.github/workflows/build-main-releases.yml
@@ -66,9 +66,6 @@ jobs:
         chown -R root /usr/local/lib/R/
         chown -R root /usr/lib/R/
 
-    - name: Install R package dependencies for VisualizationTools using Rscript
-      run: Rscript -e "install.packages(c('tidyverse', 'janitor', 'kableExtra', 'DiagrammeR', 'DiagrammeRsvg', 'rsvg', 'base64enc', 'VisualizationTools', 'plotly', 'ggplot2', 'scales'), dependencies=TRUE, repos = 'http://cran.us.r-project.org', lib = '/usr/local/lib/R/site-library')"
-
     - name: Install VisualizationTools Package using RScript from the latest release tag
       working-directory: VisualizationTools
       run: Rscript -e "install.packages('.', repos = NULL, type = 'source', lib = '/usr/local/lib/R/site-library')"

--- a/.github/workflows/check-r-package.yml
+++ b/.github/workflows/check-r-package.yml
@@ -66,9 +66,6 @@ jobs:
         chown -R root /usr/local/lib/R/
         chown -R root /usr/lib/R/
 
-    - name: Install R package dependencies for VisualizationTools using Rscript
-      run: Rscript -e "install.packages(c('tidyverse', 'janitor', 'kableExtra', 'DiagrammeR', 'DiagrammeRsvg', 'rsvg', 'base64enc', 'VisualizationTools', 'plotly', 'ggplot2', 'scales'), dependencies=TRUE, repos = 'http://cran.us.r-project.org', lib = '/usr/local/lib/R/site-library')"
-
     - name: Install VisualizationTools Package using RScript from the latest release tag
       working-directory: VisualizationTools
       run: Rscript -e "install.packages('.', repos = NULL, type = 'source', lib = '/usr/local/lib/R/site-library')"


### PR DESCRIPTION
## Summary
- The container \`eliaswf/jammy-chromedriver-python-r\` already installs every package in this list from its own [\`packages.txt\`](https://github.com/elias-jhsph/jammy-chromedriver-python-r/blob/main/packages.txt). The workflow's \`install.packages(c(...), dependencies=TRUE)\` call has no guard, so each run re-downloads and reinstalls the same binaries — ~5-10 min of pure waste.
- It also silently warns on \`'VisualizationTools'\` every run, since that package isn't on CRAN (the next step installs it from source instead).
- Matches the pattern already used by [\`build-dev-releases.yml\`](.github/workflows/build-dev-releases.yml): trust the image. Anything new the project needs should be added to the image's \`packages.txt\` (as was just done for \`km.ci\` in [jammy-chromedriver-python-r#1](https://github.com/elias-jhsph/jammy-chromedriver-python-r/pull/1)), not patched in at workflow runtime.

## Test plan
- [ ] Merge → next CI run on \`main\` should complete several minutes faster and still build green.
- [ ] If a future dep is missing, add it to \`packages.txt\` in the image repo rather than reintroducing this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)